### PR TITLE
HDInsight 3.5 compatibility

### DIFF
--- a/EventHubReader/EventHubReader.csproj
+++ b/EventHubReader/EventHubReader.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props')" />
+  <Import Project="..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,17 +36,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.14.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.4\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.SCPLogger, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\Microsoft.SCPLogger.dll</HintPath>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.SCPNet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\Microsoft.SCPNet.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\Microsoft.SCPNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -54,19 +49,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SCPHost, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPHost.exe</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SCPLogger.Log4net, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPLogger.Log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SCPPerfCounter, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPPerfCounter.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SCPPerfCounterWrapper, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPPerfCounterWrapper.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\SCPHost.exe</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -78,11 +61,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Thrift, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\Thrift.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\Thrift.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ZooKeeperNet, Version=3.4.6.1, Culture=neutral, PublicKeyToken=fefd2c046da35b56, processorArchitecture=MSIL">
-      <HintPath>..\packages\ZooKeeper.Net.3.4.6.2\lib\net40\ZooKeeperNet.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\ZooKeeperNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -106,10 +89,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets')" />
+  <Import Project="..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EventHubReader/packages.config
+++ b/EventHubReader/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.4" targetFramework="net45" />
-  <package id="Microsoft.SCP.Net.SDK" version="0.10.0.6" targetFramework="net45" />
+  <package id="Microsoft.SCP.Net.SDK" version="1.0.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="ZooKeeper.Net" version="3.4.6.2" targetFramework="net45" />
 </packages>

--- a/EventHubWriter/EventHubWriter.csproj
+++ b/EventHubWriter/EventHubWriter.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props')" />
+  <Import Project="..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="Microsoft.SCP.Net.SDK\build\Microsoft.SCP.Net.SDK.props" Condition="Exists('Microsoft.SCP.Net.SDK\build\Microsoft.SCP.Net.SDK.props')" />
   <PropertyGroup>
@@ -39,15 +39,11 @@
   <ItemGroup>
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.SCPLogger, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\Microsoft.SCPLogger.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.SCPNet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\Microsoft.SCPNet.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\Microsoft.SCPNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -56,19 +52,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SCPHost, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPHost.exe</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SCPLogger.Log4net, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPLogger.Log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SCPPerfCounter, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPPerfCounter.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SCPPerfCounterWrapper, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\SCPPerfCounterWrapper.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\SCPHost.exe</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -83,12 +67,12 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Thrift, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\Thrift.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\Thrift.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ZooKeeperNet, Version=3.4.6.1, Culture=neutral, PublicKeyToken=fefd2c046da35b56, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\lib\net45\ZooKeeperNet.dll</HintPath>
+      <HintPath>..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\lib\net45\ZooKeeperNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -115,10 +99,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.0.10.0.6\build\Microsoft.SCP.Net.SDK.targets')" />
+  <Import Project="..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets" Condition="Exists('..\packages\Microsoft.SCP.Net.SDK.1.0.0.1\build\Microsoft.SCP.Net.SDK.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EventHubWriter/EventHubWriterTopology.cs
+++ b/EventHubWriter/EventHubWriterTopology.cs
@@ -36,7 +36,7 @@ namespace EventHubWriter
             //C# components
             List<string> javaDeserializerInfo =
                 new List<string>() { "microsoft.scp.storm.multilang.CustomizedInteropJSONDeserializer", "java.lang.String" };
-            
+
             //Set the spout
             topologyBuilder.SetSpout(
                 "Spout",
@@ -51,8 +51,8 @@ namespace EventHubWriter
             //Create constructor for the Java bolt
             JavaComponentConstructor constructor =
                 JavaComponentConstructor.CreateFromClojureExpr(
-                String.Format(@"(org.apache.storm.eventhubs.bolt.EventHubBolt. (org.apache.storm.eventhubs.bolt.EventHubBoltConfig. " +
-                @"""{0}"" ""{1}"" ""{2}"" ""{3}"" ""{4}"" {5}))",
+                    String.Format(@"(org.apache.storm.eventhubs.bolt.EventHubBolt. (org.apache.storm.eventhubs.bolt.EventHubBoltConfig. " +
+                    @"""{0}"" ""{1}"" ""{2}"" ""{3}"" ""{4}"" {5}))",
                 ConfigurationManager.AppSettings["EventHubPolicyName"],
                 ConfigurationManager.AppSettings["EventHubPolicyKey"],
                 ConfigurationManager.AppSettings["EventHubNamespace"],

--- a/EventHubWriter/EventHubWriterTopology.cs
+++ b/EventHubWriter/EventHubWriterTopology.cs
@@ -51,7 +51,7 @@ namespace EventHubWriter
             //Create constructor for the Java bolt
             JavaComponentConstructor constructor =
                 JavaComponentConstructor.CreateFromClojureExpr(
-                String.Format(@"(com.microsoft.eventhubs.bolt.EventHubBolt. (com.microsoft.eventhubs.bolt.EventHubBoltConfig. " +
+                String.Format(@"(org.apache.storm.eventhubs.bolt.EventHubBolt. (org.apache.storm.eventhubs.bolt.EventHubBoltConfig. " +
                 @"""{0}"" ""{1}"" ""{2}"" ""{3}"" ""{4}"" {5}))",
                 ConfigurationManager.AppSettings["EventHubPolicyName"],
                 ConfigurationManager.AppSettings["EventHubPolicyKey"],

--- a/EventHubWriter/packages.config
+++ b/EventHubWriter/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SCP.Net.SDK" version="0.10.0.6" targetFramework="net45" />
+  <package id="Microsoft.SCP.Net.SDK" version="1.0.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ author: blackmist
 
 # Read and write from EventHubs using a hybrid .NET/Java Storm topology
 
-An example of using a hybrid dotnet/Java-based Apache Storm topology to work with Azure Event Hubs
+An example of using a hybrid dotnet/Java-based Apache Storm topology to work with Azure Event Hubs.
+
+NOTE: This example requires a Storm on HDInsight cluster version 3.5. There are breaking changes 
 
 ##Prerequisites
 
@@ -14,9 +16,14 @@ An example of using a hybrid dotnet/Java-based Apache Storm topology to work wit
 
 * **Azure SDK for Visual Studio** - at least version 2.5. This gives you the Azure entries in Server Explorer and the ability to view things like table storage
 
+* [Java](https://java.com). Java is used to package the topology when it is submitted to the HDInsight cluster.
+
+    * The **JAVA_HOME** environment variable must point to the directory that contains Java.
+    * The **%JAVA_HOME%/bin** directory must be in the path
+
 * **HDInsight Tools for Visual Studio** - [http://azure.microsoft.com/en-us/documentation/articles/hdinsight-hadoop-visual-studio-tools-get-started/](http://azure.microsoft.com/en-us/documentation/articles/hdinsight-hadoop-visual-studio-tools-get-started/) has the steps to install and configure. This provides C# Storm topology templates and some utilities for working with HDInsight
 
-* **eventhubs-storm-spout** jar file - this contains the Event Hub Spout and Bolt. You an find this in the **lib/eventhubs** folder of the [https://github.com/hdinsight/hdinsight-storm-examples](https://github.com/hdinsight/hdinsight-storm-examples) repository
+* **eventhubs-storm-spout** jar file - this contains the Event Hub Spout and Bolt. Download the version at [https://000aarperiscus.blob.core.windows.net/certs/storm-eventhubs-1.0.2-jar-with-dependencies.jar](https://000aarperiscus.blob.core.windows.net/certs/storm-eventhubs-1.0.2-jar-with-dependencies.jar) for use with this example.
 
 * **Azure Event Hub** - you need to create an Event Hub, with two policies defined - one that can send, and one that can listen. You will need the following information from the Event Hub configuration.
 
@@ -30,17 +37,13 @@ An example of using a hybrid dotnet/Java-based Apache Storm topology to work wit
 	
 	For information on creating an Event Hub and policies, see [Get Started with Event Hubs](https://azure.microsoft.com/en-us/documentation/articles/event-hubs-csharp-ephcs-getstarted/).
 
-* **Storm on HDInsight cluster** - the Azure HDInsight cluster that you will submit the topologies to
+* **Storm on HDInsight cluster** - the Azure HDInsight cluster that you will submit the topologies to. This example _requires_ Storm on HDInsight 3.5.
+
+    Storm on HDInsight 3.5 includes Storm 1.0.1. There are breaking changes in the class namespace for Storm components, which cause problems if you try to use this example against earlier versions of Storm.
 
 ## SCP.NET package version
 
-The SCP.NET package version that you use for this project depends on the version of Storm installed on your HDInsight cluster. Use the following table to determine what SCP.NET version you must use in your project:
-
-| HDInsight version | Apache Storm version | SCP.NET version |
-|:-----------------:|:--------------------:|:---------------:|
-| 3.3 | 0.10.# | 0.10.#.# |
-| 3.4 | 0.10.# | 0.10.#.# |
-| 3.5 | 1.0.# | 1.0.#.# |
+The SCP.NET package version that you use for this project depends on the version of Storm installed on your HDInsight cluster. Use SCP 1.0.#.# with this example, since it is for Storm 1.0.#, which is on HDInsight 3.5.
 
 ##Build and deploy
 
@@ -56,7 +59,7 @@ The two topologies in this project work together - EventHubWriter writes events,
 
     * Use the drop-down to select the Storm on HDInsight server
 
-    * Expand **Additional Configurations**, select **Java File Paths**, and browse or enter the path to the directory that contains the **eventhubs-storm-spout-0.9-jar-with-dependencies.jar** file.
+    * Expand **Additional Configurations**, select **Java File Paths**, and browse or enter the path to the directory that contains the **storm-eventhubs-1.0.2-jar-with-dependencies.jar** file.
 
     * Select **Submit** to submit the topology to the server
 


### PR DESCRIPTION
Updating main to be compatible with Storm on HDInsight 3.5.

There are breaking changes in the classname of core Storm components (Java,) that are the primary driver for this update. These change require the use of a new EventHubSpout jar file (linked from the README.md,) and the classname referenced for the Bolt component in EventHubWriterTopology.cs.

Beyond this, there is also a specific version of the SCP.NET framework required for HDInsight 3.5 clusters; the 1.0.0.x version. 